### PR TITLE
cxx11 incompatibility fix

### DIFF
--- a/Formula/php53-intl.rb
+++ b/Formula/php53-intl.rb
@@ -17,10 +17,7 @@ class Php53Intl < AbstractPhp53Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php53-phalcon.rb
+++ b/Formula/php53-phalcon.rb
@@ -19,12 +19,8 @@ class Php53Phalcon < AbstractPhp53Extension
   depends_on "pcre"
 
   def install
-    if MacOS.prefer_64_bit?
-      Dir.chdir "build/64bits"
-    else
-      Dir.chdir "build/32bits"
-    end
-
+    
+    Dir.chdir "build/64bits"
     ENV.universal_binary if build.universal?
 
     safe_phpize

--- a/Formula/php53-zenddebugger.rb
+++ b/Formula/php53-zenddebugger.rb
@@ -11,15 +11,9 @@ class Php53Zenddebugger < AbstractPhp53Extension
     sha256 "c18af0f8a34dfd3ca92a030c01b87f03182ea3107d720d3439ee0a3a1d94d3b4" => :mavericks
   end
 
-  if MacOS.prefer_64_bit?
-    url "http://downloads.zend.com/studio_debugger/20100729/ZendDebugger-20100729-darwin9.5-x86_64.tar.gz"
-    sha256 "87a7526738e1de1b20e055f06b7cfc46292e96e79a063893911e3ec42efa6213"
-    version "20100729"
-  else
-    url "http://downloads.zend.com/studio_debugger/2011_04_10/ZendDebugger-20110410-darwin-i386.tar.gz"
-    sha256 "23b6bee02df3de787d77f8f5e4b51f14a2d717ddea7d81b1f7e87815dd238e79"
-    version "20110410"
-  end
+  url "http://downloads.zend.com/studio_debugger/20100729/ZendDebugger-20100729-darwin9.5-x86_64.tar.gz"
+  sha256 "87a7526738e1de1b20e055f06b7cfc46292e96e79a063893911e3ec42efa6213"
+  version "20100729"
 
   def extension_type
     "zend_extension"

--- a/Formula/php54-intl.rb
+++ b/Formula/php54-intl.rb
@@ -17,10 +17,7 @@ class Php54Intl < AbstractPhp54Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php54-phalcon.rb
+++ b/Formula/php54-phalcon.rb
@@ -19,11 +19,8 @@ class Php54Phalcon < AbstractPhp54Extension
   depends_on "pcre"
 
   def install
-    if MacOS.prefer_64_bit?
-      Dir.chdir "build/64bits"
-    else
-      Dir.chdir "build/32bits"
-    end
+    
+    Dir.chdir "build/64bits"
 
     ENV.universal_binary if build.universal?
 

--- a/Formula/php55-intl.rb
+++ b/Formula/php55-intl.rb
@@ -16,10 +16,7 @@ class Php55Intl < AbstractPhp55Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php56-intl.rb
+++ b/Formula/php56-intl.rb
@@ -10,10 +10,7 @@ class Php56Intl < AbstractPhp56Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php70-intl.rb
+++ b/Formula/php70-intl.rb
@@ -11,10 +11,7 @@ class Php70Intl < AbstractPhp70Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php71-intl.rb
+++ b/Formula/php71-intl.rb
@@ -11,10 +11,7 @@ class Php71Intl < AbstractPhp71Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/php72-intl.rb
+++ b/Formula/php72-intl.rb
@@ -11,10 +11,7 @@ class Php72Intl < AbstractPhp72Extension
   
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
     Dir.chdir "ext/intl"
 
     safe_phpize

--- a/Formula/phpmyadmin3.rb
+++ b/Formula/phpmyadmin3.rb
@@ -21,9 +21,7 @@ class Phpmyadmin3 < Formula
     depends_on "php70-mcrypt" if Formula["php70"].linked_keg.exist?
   end
 
-  unless MacOS.prefer_64_bit?
-    option "without-mcrypt", "Exclude the php-mcrypt module"
-  end
+  option "without-mcrypt", "Exclude the php-mcrypt module"
 
   def install
     (share+"phpmyadmin3").install Dir["*"]


### PR DESCRIPTION
Recently got the error `Calling needs :cxx11 is disabled! There is no replacement.`

I removed the x86 support since only very old mac os is using it. Hope it will solve the issue.